### PR TITLE
Update Strava authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To obtain your current profile:
 * Get CLIENT_ID and CLIENT_SECRET from https://www.strava.com/settings/api
 * Run ``scripts/strava_auth.py --client-id CLIENT_ID --client-secret CLIENT_SECRET``
 * Open http://localhost:8000/ and authorize.
-* Add the resulting access token to ``storage/strava_token.txt``
+* Move the resulting strava_token.txt (saved in whatever directory you ran strava_auth.py in) into the ``storage`` directory.
 
 
 ## Dependencies
@@ -170,7 +170,6 @@ Docker
   * ``pip install protobuf_to_dict``
 * OPTIONAL: stravalib (https://github.com/hozn/stravalib)
   * ``pip install stravalib``
-  * Add your Strava API token to ``storage/strava_token.txt``
 
 
 ## Known issues

--- a/scripts/strava_auth.py
+++ b/scripts/strava_auth.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 """
-Same as https://github.com/hozn/stravalib/blob/master/stravalib/tests/auth_responder.py
-
-Just added "scope=write" to the authorization URL.
-
 A basic authorization server.  Run this with your Strava Client ID and Client Secret and access from your
 browser (because the Strava OAuth page uses javascript) in order to get a resulting access token.  That access
 token can then be used to initialize a Client that can read (and/or write) data from the Strava API.
@@ -65,18 +61,29 @@ class RequestHandler(BaseHTTPRequestHandler):
             code = urlparse.parse_qs(parsed_path.query).get('code')
             if code:
                 code = code[0]
-                access_token = client.exchange_code_for_token(client_id=self.server.client_id,
+                token_response = client.exchange_code_for_token(client_id=self.server.client_id,
                                                               client_secret=self.server.client_secret,
                                                               code=code)
+                access_token = token_response['access_token']
+                refresh_token = token_response['refresh_token']
+                expires_at = token_response['expires_at']
                 self.server.logger.info("Exchanged code {} for access token {}".format(code, access_token))
                 self.wfile.write(six.b("Access Token: {}\n".format(access_token)))
+                self.wfile.write(six.b("Refresh Token: {}\n".format(refresh_token)))
+                self.wfile.write(six.b("Expires at: {}\n".format(expires_at)))
+                with open('strava_token.txt', 'w') as f:
+                    f.write(self.server.client_id + '\n');
+                    f.write(self.server.client_secret + '\n');
+                    f.write(access_token + '\n');
+                    f.write(refresh_token + '\n');
+                    f.write(str(expires_at) + '\n');
             else:
                 self.server.logger.error("No code param received.")
                 self.wfile.write(six.b("ERROR: No code param recevied.\n"))
         else:
             url = client.authorization_url(client_id=self.server.client_id,
                                            redirect_uri='http://localhost:{}/authorization'.format(self.server.server_port),
-                                           scope='write')
+                                           scope='activity:write')
 
             self.send_response(302)
             self.send_header(six.b("Content-type"), six.b("text/plain"))


### PR DESCRIPTION
Use short-lived access_token, expires_at and refresh_token instead of "forever" access_token (issue #17).