### PR TITLE
Update to Zwift 1.0.50775

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ zoffline can be installed on the same machine as Zwift or another local machine.
 <details><summary>Windows 10 Instructions</summary>
 
 * Install Zwift
-  * If your Zwift version is 1.0.49821, you're all set.
+  * If your Zwift version is 1.0.50775, you're all set.
   * If Zwift is not installed, install it before installing zoffline.
-  * If your Zwift version is newer than 1.0.49821 and zoffline is running from source: copy ``C:\Program Files (x86)\Zwift\Zwift_ver_cur.xml`` to zoffline's ``cdn/gameassets/Zwift_Updates_Root/`` overwriting the existing file.
-  * If your Zwift version is newer than 1.0.49821 and zoffline is not running from source: wait for zoffline to be updated.
+  * If your Zwift version is newer than 1.0.50775 and zoffline is running from source: copy ``C:\Program Files (x86)\Zwift\Zwift_ver_cur.xml`` to zoffline's ``cdn/gameassets/Zwift_Updates_Root/`` overwriting the existing file.
+  * If your Zwift version is newer than 1.0.50775 and zoffline is not running from source: wait for zoffline to be updated.
 * On your Windows machine running Zwift, copy the following files in this repo to a known location:
   * ``ssl/cert-zwift-com.p12``
   * ``ssl/cert-zwift-com.pem``
@@ -91,9 +91,9 @@ to generate your own certificates and do the same.
 <details><summary>Mac OS X Instructions (Thanks @oldnapalm!)</summary>
 
 * Install Zwift
-  * If your Zwift version is 1.0.49821, you're all set.
+  * If your Zwift version is 1.0.50775, you're all set.
   * If Zwift is not installed, install it before installing zoffline.
-  * If your Zwift version is newer than 1.0.49821: copy ``~/Library/Application Support/Zwift/ZwiftMac_ver_cur.xml`` to zoffline's ``cdn/gameassets/Zwift_Updates_Root/`` overwriting the existing file.
+  * If your Zwift version is newer than 1.0.50775: copy ``~/Library/Application Support/Zwift/ZwiftMac_ver_cur.xml`` to zoffline's ``cdn/gameassets/Zwift_Updates_Root/`` overwriting the existing file.
 * On your Mac machine running Zwift, copy the following files in this repo to a known location:
   * ``ssl/cert-zwift-com.p12``
   * ``ssl/cert-zwift-com.pem``

--- a/cdn/gameassets/Zwift_Updates_Root/ZwiftMac_ver_cur.xml
+++ b/cdn/gameassets/Zwift_Updates_Root/ZwiftMac_ver_cur.xml
@@ -1,7 +1,7 @@
 <Zwift
-version="1.0.49821"
+version="1.0.50775"
 GAME_URL="https://us-or-rly101.zwift.com"
-manifest="ZwiftMac_1.0.49821_3fa59fcb_manifest.xml"
-manifest_checksum="895333465"
+manifest="ZwiftMac_1.0.50775_0e8b8e90_manifest.xml"
+manifest_checksum="1129281015"
 mandatory_version="0.0.0"
-ver_cur_checksum="194500175"/>
+ver_cur_checksum="-179929382"/>

--- a/cdn/gameassets/Zwift_Updates_Root/Zwift_ver_cur.xml
+++ b/cdn/gameassets/Zwift_Updates_Root/Zwift_ver_cur.xml
@@ -1,7 +1,7 @@
 <Zwift
-version="1.0.49821"
+version="1.0.50775"
 GAME_URL="https://us-or-rly101.zwift.com"
-manifest="Zwift_1.0.49821_3fa59fcb_manifest.xml"
-manifest_checksum="2075192503"
+manifest="Zwift_1.0.50775_0e8b8e90_manifest.xml"
+manifest_checksum="857390218"
 mandatory_version="0.0.0"
-ver_cur_checksum="-1683393525"/>
+ver_cur_checksum="1697453729"/>

--- a/protobuf/udp-node-msgs.proto
+++ b/protobuf/udp-node-msgs.proto
@@ -1,8 +1,8 @@
 message PlayerState {
-	required int32 id = 1;
-	required int64 worldTime = 2;
+	optional int32 id = 1;
+	optional int64 worldTime = 2;
 	optional int32 distance = 3;
-	optional int32 roadTime = 4;
+	required int32 roadTime = 4;
 	optional int32 laps = 5;
 	optional int32 speed = 6;
 	optional int32 roadPosition = 8;

--- a/protobuf/udp-node-msgs.proto
+++ b/protobuf/udp-node-msgs.proto
@@ -1,20 +1,20 @@
 message PlayerState {
 	required int32 id = 1;
 	required int64 worldTime = 2;
-	required int32 distance = 3;
-	required int32 roadTime = 4;
+	optional int32 distance = 3;
+	optional int32 roadTime = 4;
 	optional int32 laps = 5;
-	required int32 speed = 6;
+	optional int32 speed = 6;
 	optional int32 roadPosition = 8;
 	optional int32 cadenceUHz = 9;
 	optional int32 heartrate = 11;
-	required int32 power = 12;
+	optional int32 power = 12;
 	optional int64 heading = 13;
 	optional int32 lean = 14;
 	optional int32 climbing = 15;
-	required int32 time = 16;
-	required int32 f19 = 19;
-	required int32 f20 = 20;
+	optional int32 time = 16;
+	optional int32 f19 = 19;
+	optional int32 f20 = 20;
 	optional int32 progress = 21;
 	optional int64 customisationId = 22;
 	optional int32 justWatching = 23;
@@ -25,7 +25,7 @@ message PlayerState {
 	optional int32 watchingRiderId = 28;
 	optional int32 groupId = 29;
 	optional int64 sport = 31;
-	required float f34 = 34;
+	optional float f34 = 34;
 }
 
 message ClientToServer {


### PR DESCRIPTION
Had an issue with SerializeToString when there was no "power" field and it's defined as "required" in protobuf. Happened because I use virtual power (estimated from speed sensor) and looks like in this case when power is zero the field is missing. Should all fields be optional (except id and world_time which we know will always be set)?