### PR TITLE
Add batch script to configure Windows 10 client

### DIFF
--- a/scripts/configure_client.bat
+++ b/scripts/configure_client.bat
@@ -1,0 +1,49 @@
+@ECHO OFF
+TITLE configure_client
+ECHO Configuring Zwift client to use zoffline server
+ECHO.
+
+NET SESSION >nul 2>&1 || ( PowerShell start -verb runas '%~0' & EXIT /B )
+
+CD /D "%~dp0"
+
+SET HOSTS="%WINDIR%\system32\drivers\etc\hosts"
+>nul 2>&1 FIND /C /I "zwift.com" %HOSTS%
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO Adding servers to hosts file
+    ECHO.>>%HOSTS%
+    ECHO 127.0.0.1 us-or-rly101.zwift.com secure.zwift.com cdn.zwift.com launcher.zwift.com>>%HOSTS%
+) ELSE ( ECHO Servers found in hosts file, no changes will be made )
+
+ECHO.
+
+certutil.exe -store Root | FIND /C /I "zwift.com" >nul 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO Importing certificate
+    ECHO.|certutil.exe -importpfx Root ..\ssl\cert-zwift-com.p12
+) ELSE ( ECHO Certificate found in root store, no changes will be made )
+
+ECHO.
+
+SET ZWIFT=zwift_location.txt
+IF EXIST %ZWIFT% ( SET /P FOLDER=<%ZWIFT%
+) ELSE ( SET FOLDER="%SystemDrive%\Program Files (x86)\Zwift")
+SET CACERT=%FOLDER%\data\cacert.pem
+IF EXIST %CACERT% GOTO:FOUND
+:NOT_FOUND
+SET COMMAND="(new-object -COM 'Shell.Application').BrowseForFolder(0,'Please locate Zwift folder',0,0).self.path"
+FOR /F "usebackq delims=" %%I IN (`PowerShell %COMMAND%`) DO SET FOLDER="%%I"
+SET CACERT=%FOLDER%\data\cacert.pem
+IF NOT EXIST %CACERT% GOTO:NOT_FOUND
+ECHO %FOLDER%>%ZWIFT%
+:FOUND
+>nul 2>&1 FIND /C "MIIEowIBAAKCAQEAuPBKWMw8+OtDjAsZuXUpc89SDWSi5iyS1kfddC6UK6UC5Tsy" %CACERT%
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO Adding certificate to cacert.pem
+    ECHO.>>%CACERT%
+    TYPE ..\ssl\cert-zwift-com.pem>>%CACERT%
+) ELSE ( ECHO Certificate found in cacert.pem, no changes will be made )
+
+ECHO.
+
+PAUSE


### PR DESCRIPTION
Not sure if you want to merge this, so opening pull request even being a minimal change.

I created a release (not in zoffline repo) with pyinstaller exes of get_profile and strava_auth. In strava_auth I used client-id and client-secret created by me, not sure if this can be a problem. If you want I can add the release in zoffline or remove it if it's an issue with Strava.

https://github.com/oldnapalm/zoffline-helper/releases/tag/zoffline_helper
