### PR TITLE
Add instructions for non rooted android devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,36 @@ to generate your own certificates and do the same.
 
 </details>
 
-<details><summary>Android (requires a rooted device)</summary>
+<details><summary>Android (non-rooted device)</summary>
+
+* Install required apps:
+  * Install zoffline-obb.apk from https://github.com/Argon2000/ZofflineObbAndroid/blob/master/app/release/zoffline-obb.apk
+  * Download "Host Changer VPN - The Game Changer" from Google play [[link here]](https://play.google.com/store/apps/details?id=com.hostchanger.gamingvpn.gamechanger)
+  * Create a `hosts.txt` file to use with the app (you could use a text editor app or create it online with an online tool such as [this](https://passwordsgenerator.net/text-editor/). The file must look like this (replace <your ip> with an actual IP):
+  
+  ```
+  <your ip> us-or-rly101.zwift.com
+  <your ip> secure.zwift.com
+  <your ip> cdn.zwift.com
+  ```
+  * Run `Host Changer`, select created `hosts.txt` file and press the button
+* Patch after every installation or update:
+  * Install/update Zwift from Google play, do not start it.
+    * If you have already started it go to `Android Settings > Applications > Zwift` and clear data or uninstall and reinstall the app.
+  * Open `ZofflineObb` apk and run it (allow access to storage)
+  * Wait for process to finish (5-10min)
+  * Run Zwift, hopefully it verifies download and runs
+* Play zwift:
+  * Host Changer button must be ON
+  * Start Zwift and sign in using any email/password
+    * If multiplayer is enabled, access `https://<your ip>/signup/` to sign up and import your files. (You must accept an invalid certificate alert).
+
+Why: We need to redirect Zwift to use zoffline (this is done by the VPN app) and convince Zwift to
+accept zoffline's self signed certificates for Zwift's domain names (this is done by the patch tool ZofflineObb).
+
+</details>
+
+<details><summary>Android (rooted device)</summary>
 
 * Install Zwift on the device
 * Open Zwift once to complete installation (i.e download all extra files).


### PR DESCRIPTION
Here are the instructions to use zwift client with zwift-offline on non rooted android devices. I have used some of the notes written by @Argon2000 in the discord channel.