### PR TITLE
Apache VirtualHosts Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,11 +293,11 @@ To enable support for multiple users perform the steps below. zoffline's previou
   ```
  * To disable the web server and run your own apache web server you must comment out lines 616-620 in standalone.py:
   ```
-   #socketserver.ThreadingTCPServer.allow_reuse_address = True
-   #httpd = socketserver.ThreadingTCPServer(('', 80), CDNHandler)
-   #zoffline_thread = threading.Thread(target=httpd.serve_forever)
-   #zoffline_thread.daemon = True
-   #zoffline_thread.start()
+  #socketserver.ThreadingTCPServer.allow_reuse_address = True
+  #httpd = socketserver.ThreadingTCPServer(('', 80), CDNHandler)
+  #zoffline_thread = threading.Thread(target=httpd.serve_forever)
+  #zoffline_thread.daemon = True
+  #zoffline_thread.start()
   ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ To enable support for multiple users perform the steps below. zoffline's previou
   MinProtocol = TLSv1.0
   CipherString = DEFAULT@SECLEVEL=1
   ```
-  * To disable the web server and run your own apache web server you must comment out lines 616-620 in standalone.py:
+ * To disable the web server and run your own apache web server you must comment out lines 616-620 in standalone.py:
   ```
    #socketserver.ThreadingTCPServer.allow_reuse_address = True
    #httpd = socketserver.ThreadingTCPServer(('', 80), CDNHandler)

--- a/README.md
+++ b/README.md
@@ -291,6 +291,14 @@ To enable support for multiple users perform the steps below. zoffline's previou
   MinProtocol = TLSv1.0
   CipherString = DEFAULT@SECLEVEL=1
   ```
+  * To disable the web server and run your own apache web server you must comment out lines 616-620 in standalone.py:
+  ```
+   #socketserver.ThreadingTCPServer.allow_reuse_address = True
+   #httpd = socketserver.ThreadingTCPServer(('', 80), CDNHandler)
+   #zoffline_thread = threading.Thread(target=httpd.serve_forever)
+   #zoffline_thread.daemon = True
+   #zoffline_thread.start()
+  ```
 </details>
 
 ## Community Discord and zoffline (online) server

--- a/README.md
+++ b/README.md
@@ -291,13 +291,18 @@ To enable support for multiple users perform the steps below. zoffline's previou
   MinProtocol = TLSv1.0
   CipherString = DEFAULT@SECLEVEL=1
   ```
- * To disable the web server and run your own apache web server you must comment out lines 616-620 in standalone.py:
+ * To disable the web server that runs on port 80 and run your own apache web server you must comment out lines 616-620 in standalone.py:
   ```
   #socketserver.ThreadingTCPServer.allow_reuse_address = True
   #httpd = socketserver.ThreadingTCPServer(('', 80), CDNHandler)
   #zoffline_thread = threading.Thread(target=httpd.serve_forever)
   #zoffline_thread.daemon = True
   #zoffline_thread.start()
+  ```
+   * You must also disable the SSL web server by commenting out lines 1750-1751 in zwift_offline.py:
+  ```
+  #server = WSGIServer(('0.0.0.0', 443), app, certfile='%s/cert-zwift-com.pem' % SSL_DIR, keyfile='%s/key-zwift-com.pem' % SSL_DIR, log=logger)
+  #server.serve_forever()
   ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -300,10 +300,14 @@ To enable support for multiple users perform the steps below. zoffline's previou
   #zoffline_thread.start()
   ```
    * You must also disable the SSL web server by commenting out lines 1750-1751 in zwift_offline.py:
+  
   ```
   #server = WSGIServer(('0.0.0.0', 443), app, certfile='%s/cert-zwift-com.pem' % SSL_DIR, keyfile='%s/key-zwift-com.pem' % SSL_DIR, log=logger)
   #server.serve_forever()
   ```
+   * Instead of disabling the web server components, you can proxy both the unsecure port 80 connection and the SSL port 443 connection using apache virtual host with a few apache proxy modules. An example of these configurations is available under the apache directory.
+
+  
 </details>
 
 ## Community Discord and zoffline (online) server

--- a/apache/cdn.zwift.com.conf
+++ b/apache/cdn.zwift.com.conf
@@ -1,22 +1,7 @@
 <VirtualHost *:80>
-        DocumentRoot /var/www/zwift-offline/cdn
-        ServerName cdn.zwift.com
-
-        <Directory /var/www/zwift-offline/cdn/>
-                Options -Indexes
-                AllowOverride None
-                Order allow,deny
-                allow from all
-        </Directory>
-
-        #ProxyPass "/gameassets/MapSchedule.xml" "http://cdn.zwift.com/gameassets/MapSchedule.xml"
-        #ProxyPass "/gameassets/MapSchedule_v2.xml" "http://cdn.zwift.com/gameassets/MapSchedule_v2.xml"
-
-	# XXX: This update file proxying will not work if running Zwift on the same machine
-        ProxyPassMatch "/gameassets/Zwift_Updates_Root/(Zwift(?:Mac)?_[0-9]+.[0-9]+.[0-9]+_manifest.xml)" "http://cdn.zwift.com/gameassets/Zwift_Updates_Root/$1"
-        ProxyPassMatch "/gameassets/Zwift_Updates_Root/(Zwift_[0-9]+.[0-9]+.[0-9]+)/(.*)" "http://cdn.zwift.com/gameassets/Zwift_Updates_Root/$1/$2"
-
-        LogLevel warn
-        CustomLog /var/log/apache2/cdn_zwift_access.log combined
-        ErrorLog /var/log/apache2/cdn_zwift_error.log
+        ServerAdmin xxxxx@xxxxx.com
+        ServerName zwift.your-domain.com
+        ServerAlias cdn.zwift.com
+        ProxyPass / http://<zwift-offline server ip>/
+        ProxyPassReverse / http://<zwift-offline server ip>/
 </VirtualHost>

--- a/apache/zwift-offline.conf
+++ b/apache/zwift-offline.conf
@@ -1,7 +1,7 @@
 <VirtualHost *:443>
         DocumentRoot /var/www/zwift-offline
         ServerName us-or-rly101.zwift.com
-        ServerAlias secure.zwift.com
+        ServerAlias secure.zwift.com launcher.zwift.com
 
         WSGIScriptAlias / /var/www/zwift-offline/zwift-offline.wsgi
 

--- a/apache/zwift-offline.conf
+++ b/apache/zwift-offline.conf
@@ -1,21 +1,19 @@
 <VirtualHost *:443>
-        DocumentRoot /var/www/zwift-offline
-        ServerName us-or-rly101.zwift.com
-        ServerAlias secure.zwift.com launcher.zwift.com
+        ServerAdmin xxxxx@xxxxx.com
+        ServerName zwift.your-domain.com
+        ServerAlias us-or-rly101.zwift.com cdn.zwift.com secure.zwift.com launcher.zwift.com
 
-        WSGIScriptAlias / /var/www/zwift-offline/zwift-offline.wsgi
+        SSLProxyEngine On
+        SSLProxyVerify none
+        SSLProxyCheckPeerCN off
+        SSLProxyCheckPeerName off
+        SSLProxyCheckPeerExpire off
+        ProxyRequests On
+        ProxyPreserveHost On
+        RequestHeader set "X-Forwarded-Proto" "https"
 
-        <Directory /var/www/zwift-offline/>
-                Options -Indexes
-                AllowOverride None
-                Order allow,deny
-                allow from all
-        </Directory>
-
-        LogLevel warn
-        CustomLog /var/log/apache2/zwift_offline_access.log combined
-        ErrorLog /var/log/apache2/zwift_offline_error.log
-
+        ProxyPass / https://<zwift-offline server ip>/
+        ProxyPassReverse / https://<zwift-offline server ip>/
         SSLCertificateFile /var/www/zwift-offline/ssl/cert-zwift-com.pem
         SSLCertificateKeyFile /var/www/zwift-offline/ssl/key-zwift-com.pem
 </VirtualHost>


### PR DESCRIPTION
Changed the apache configs to only proxy connections to the main zwift online python scripts.
This  is to use your own separate dedicated webserver on a different machine.

Updated documentation with a few extra bits information from the main devs on how to disable web server portions of the python scripts. 