### PR TITLE
Runalyze Upload functionality

### DIFF
--- a/zwift_offline.py
+++ b/zwift_offline.py
@@ -1008,7 +1008,7 @@ def garmin_upload(player_id, activity):
     except:
         logger.warn("Garmin upload failed. No internet?")
 
-def runalyze_upload(player_id):
+def runalyze_upload(player_id, activity):
     profile_dir = '%s/%s' % (STORAGE_DIR, player_id)
     try:
         with open('%s/runalyze_token.txt' % profile_dir, 'r') as f:
@@ -1017,10 +1017,16 @@ def runalyze_upload(player_id):
         logger.warn("Failed to read %s/runalyze_token.txt. Skipping Runalyze upload attempt." % profile_dir)
         return
     try:
+        with open('%s/last_activity.fit' % profile_dir, 'wb') as f:
+            f.write(activity.fit)
+    except:
+        logger.warn("Failed to save fit file. Skipping Runalyze upload attempt.")
+        return
+    try:
         r = requests.post("https://runalyze.com/api/v1/activities/uploads",
                           files={'file': open('%s/last_activity.fit' % profile_dir, "rb")},
                           headers={"token": runtoken})
-        print(r.text)
+        logger.info(r.text)
     except:
         logger.warn("Runalyze upload failed. No internet?")
 
@@ -1054,7 +1060,7 @@ def api_profiles_activities_id(player_id, activity_id):
     # will occur with these profiles).
     strava_upload(player_id, activity)
     garmin_upload(player_id, activity)
-    runalyze_upload(player_id)
+    runalyze_upload(player_id, activity)
     # For using with upload_activity.py (to upload zoffline activity to Zwift server)
     with open('%s/%s/last_activity.bin' % (STORAGE_DIR, player_id), 'wb') as f:
         f.write(activity.SerializeToString())


### PR DESCRIPTION
Functionality to automatically upload Zwift workout data to Runalyze. 
- get Runalyze Personal API token from https://runalyze.com/settings/personal-api 
- create text file with one line only, put the API token in this file. Save as "runalyze_token.txt"
- upload using zoffline launch menu, or manual put in "storage" folder.