### PR TITLE
fix: More helpful explanation for multiplayer mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ To enable support for multiple users perform the steps below. zoffline's previou
 * Create a ``multiplayer.txt`` file in the ``storage`` directory.
 * If you are not running zoffline on the same PC that Zwift is running: create a ``server-ip.txt`` file in the ``storage`` directory containing the IP address of the PC running zoffline.
   * TCP ports 80, 443, 3023 and UDP port 3022 will need to be open on the PC running zoffline if its running remotely.
-* Start Zwift and create an account in the new Zwift launcher and upload your ``profile.bin``, ``strava_token.txt``, and/or ``garmin_credentials.txt`` if you have them.
+* Start Zwift and create an account in the new Zwift launcher (desktop solution only, for Android go to `<serverIp>/signup/`, in-app registration does not work yet) and upload your ``profile.bin``, ``strava_token.txt``, and/or ``garmin_credentials.txt`` if you have them.
   * This account will only exist on your zoffline server and has no relation with your actual Zwift account.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ accept zoffline's self signed certificates for Zwift's domain names (this is don
     * ``adb push hosts /etc/hosts``
   * Note: If you know what you're doing and have a capable enough router you can adjust your router to alter these DNS records instead of modifying your ``hosts`` file.
 * Start Zwift and sign in using any email/password
-  * If multiplayer is enabled, access https://secure.zwift.com/signup/ to sign up and import your files.
+  * If multiplayer is enabled, access `https://<zoffline ip>/signup/` to sign up and import your files.
 
 Why: We need to redirect Zwift to use zoffline and convince Zwift to
 accept zoffline's self signed certificates for Zwift's domain names. Feel free
@@ -294,7 +294,7 @@ To enable support for multiple users perform the steps below. zoffline's previou
 * Create a ``multiplayer.txt`` file in the ``storage`` directory.
 * If you are not running zoffline on the same PC that Zwift is running: create a ``server-ip.txt`` file in the ``storage`` directory containing the IP address of the PC running zoffline.
   * TCP ports 80, 443, 3023 and UDP port 3022 will need to be open on the PC running zoffline if its running remotely.
-* Start Zwift and create an account in the new Zwift launcher (desktop solution only, for Android go to `<serverIp>/signup/`, in-app registration does not work yet) and upload your ``profile.bin``, ``strava_token.txt``, and/or ``garmin_credentials.txt`` if you have them.
+* Start Zwift and create an account in the new Zwift launcher (desktop solution only, for Android go to `https://<zoffline ip>/signup/`, in-app registration does not work yet) and upload your ``profile.bin``, ``strava_token.txt``, and/or ``garmin_credentials.txt`` if you have them.
   * This account will only exist on your zoffline server and has no relation with your actual Zwift account.
 
 </details>


### PR DESCRIPTION
Thanks for creating and maintaining this project! I went through the setup yesterday (with an Android device) and spent a lot of time trying to get multiplayer registration to work until I finally saw that some html-based endpoints exist. These are used by the web version, but the mobile versions offer their own native forms and then do a POST to `/api/users` to register a user, which is not implemented in zwift-offline yet.

So I figured I would add a remark to the readme to improve the situation for newcomers.

EDIT: Just found the last bullet in the Android (non-rooted) instruction would have saved me a ton of time, as I did not realize `secure.zwift.com` is effectively the server's address (obviously it is in the hosts redirect, just a lack of association on my part), so I changed it to the android (rooted) version there.