### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/zoffline:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
+FROM python:3-alpine as builder
+
+WORKDIR /usr/src/app
+
+RUN apk add --no-cache git gcc g++ musl-dev libffi-dev openssl-dev file make
+RUN pip install --user flask flask_sqlalchemy flask-login pyjwt gevent protobuf protobuf3_to_dict stravalib garmin-uploader requests
+
+RUN git clone --depth 1 https://github.com/zoffline/zwift-offline
+
 FROM python:3-alpine
 MAINTAINER zoffline <zoffline@tutanota.com>
 
 WORKDIR /usr/src/app
 
-RUN apk add --no-cache git gcc g++ musl-dev libffi-dev openssl-dev file make
-RUN pip install flask flask_sqlalchemy flask-login pyjwt gevent protobuf protobuf3_to_dict stravalib garmin-uploader requests
+COPY --from=builder /root/.local/ /root/.local/
+ENV PATH=/root/.local/bin:$PATH
 
-RUN git clone --depth 1 https://github.com/zoffline/zwift-offline
+COPY --from=builder /usr/src/app/zwift-offline/ zwift-offline/
 RUN chmod 777 zwift-offline/storage
 
 EXPOSE 443 80 3022/udp 3023


### PR DESCRIPTION
This uses GitHub Actions to build and push docker images since DockerHub's Automatic Deployments have moved to a paid plan. The repo owner will need to set `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as repo secrets in order for these to work.

Resolves #150