### PR TITLE
Change Dockerfile to use local repo instead of master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ WORKDIR /usr/src/app
 
 RUN apk add --no-cache git gcc g++ musl-dev libffi-dev openssl-dev file make
 
-RUN git clone --depth 1 https://github.com/zoffline/zwift-offline
+RUN mkdir -p ./zwift-offline
+COPY ./ ./zwift-offline
 
-COPY requirements.txt requirements.txt
-RUN pip install --user --requirement requirements.txt
+RUN pip install --user --requirement ./zwift-offline/requirements.txt
 RUN pip install --user garth
 
 FROM python:3.12-alpine


### PR DESCRIPTION
Instead of always pulling the latest master this dockerfile is building from the current state of the locally cloned repo. 

This allows to develop on the code and then directly build the local code as a docker using `docker compose build`. 

I'm not sure if there was a reasoning in letting the Dockerfile always pull the latest master or if it's ok to build from the current state of the repo. 

If there was a reason to always clone master, then feel free to reject this PR. 