### PR TITLE
Hint added for docker-compose installation on how to use the volumes tag to be able to properly mount a local folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ zoffline can be installed on the same machine as Zwift or another local machine.
               - 3025:3025
            restart: unless-stopped    
    ```
-* in the ``volumes`` tag replace ``./storage/`` before the ``:`` with the directory path you want to use as your local zoffline data store.
+  * In the ``volumes`` tag replace ``./storage/`` before the ``:`` with the directory path you want to use as your local zoffline data store.
 * If you are not running zoffline on the same PC that Zwift is running: create a ``server-ip.txt`` file in the ``storage`` directory containing the IP address of the PC running zoffline.
 * Start zoffline with:
   ``docker-compose up -d ``

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ zoffline can be installed on the same machine as Zwift or another local machine.
               - 3025:3025
            restart: unless-stopped    
    ```
+* in the ``volumes`` tag replace ``./storage/`` before the ``:`` with the directory path you want to use as your local zoffline data store.
 * If you are not running zoffline on the same PC that Zwift is running: create a ``server-ip.txt`` file in the ``storage`` directory containing the IP address of the PC running zoffline.
 * Start zoffline with:
   ``docker-compose up -d ``


### PR DESCRIPTION
Added a hint in the "Using Docker Compose" section of the README.md file on how to use the volumes top level element to be able to mount a local folder for use with the zoffline server. 

This small amendment provides more clarity for beginner users wanting to use their existing data with a new zoffline image or for people who want to access their data even more quickly.