### PR TITLE
Increase the upload size limit for .fit files.

### DIFF
--- a/zwift_offline.py
+++ b/zwift_offline.py
@@ -153,7 +153,7 @@ if not os.path.exists(SECRET_KEY_FILE):
         f.write(os.urandom(16))
 with open(SECRET_KEY_FILE, 'rb') as f:
     app.config['SECRET_KEY'] = f.read()
-app.config['MAX_CONTENT_LENGTH'] = 1024 * 1024
+app.config['MAX_CONTENT_LENGTH'] = 4096 * 1024  # A typical .fit file with power, cadence, and heartrate data recorded in December 2024 is approximately 1.3 MB / 4 hours.
 db = SQLAlchemy()
 db.init_app(app)
 

--- a/zwift_offline.py
+++ b/zwift_offline.py
@@ -153,7 +153,7 @@ if not os.path.exists(SECRET_KEY_FILE):
         f.write(os.urandom(16))
 with open(SECRET_KEY_FILE, 'rb') as f:
     app.config['SECRET_KEY'] = f.read()
-app.config['MAX_CONTENT_LENGTH'] = 4096 * 1024  # A typical .fit file with power, cadence, and heartrate data recorded in December 2024 is approximately 1.3 MB / 4 hours.
+app.config['MAX_CONTENT_LENGTH'] = 4 * 1024 * 1024  # A typical .fit file with power, cadence, and heartrate data recorded in December 2024 is approximately 1.3 MB / 4 hours.
 db = SQLAlchemy()
 db.init_app(app)
 


### PR DESCRIPTION
This pull request includes a change to the `zwift_offline.py` file to increase the maximum content length for uploaded files. The most important change is:

* [`zwift_offline.py`](diffhunk://#diff-f4053a7fcb3c73ca8b58c6fb646b8f0e2c467edfad4759aa3a241f09b3fe2ca2L156-R156): Increased `app.config['MAX_CONTENT_LENGTH']` from 1 MB to 4 MB to accommodate larger `.fit` files.