### PR TITLE
Allow to configure cdn, api, tcp and udp host and port

### DIFF
--- a/standalone.py
+++ b/standalone.py
@@ -797,19 +797,30 @@ if os.path.isfile(ENABLE_BOTS_FILE):
     bot = threading.Thread(target=play_bots)
     bot.start()
 
+cdn_host = os.environ.get('ZOFFLINE_CDN_HOST', '')
+cdn_port = int(os.environ.get('ZOFFLINE_CDN_PORT', 80))
+
 socketserver.ThreadingTCPServer.allow_reuse_address = True
-httpd = socketserver.ThreadingTCPServer(('', 80), CDNHandler)
+httpd = socketserver.ThreadingTCPServer((cdn_host, cdn_port), CDNHandler)
 zoffline_thread = threading.Thread(target=httpd.serve_forever)
 zoffline_thread.daemon = True
 zoffline_thread.start()
 
-tcpserver = socketserver.ThreadingTCPServer(('', 3025), TCPHandler)
+
+tcp_host = os.environ.get('ZOFFLINE_TCP_HOST', '')
+tcp_port = int(os.environ.get('ZOFFLINE_TCP_PORT', 3025))
+
+tcpserver = socketserver.ThreadingTCPServer((tcp_host, tcp_port), TCPHandler)
 tcpserver_thread = threading.Thread(target=tcpserver.serve_forever)
 tcpserver_thread.daemon = True
 tcpserver_thread.start()
 
+udp_host = os.environ.get('ZOFFLINE_UDP_HOST', '')
+udp_port = int(os.environ.get('ZOFFLINE_UDP_PORT', 3024))
+
+
 socketserver.ThreadingUDPServer.allow_reuse_address = True
-udpserver = socketserver.ThreadingUDPServer(('', 3024), UDPHandler)
+udpserver = socketserver.ThreadingUDPServer((udp_host, udp_port), UDPHandler)
 udpserver_thread = threading.Thread(target=udpserver.serve_forever)
 udpserver_thread.daemon = True
 udpserver_thread.start()

--- a/zwift_offline.py
+++ b/zwift_offline.py
@@ -4139,7 +4139,19 @@ def run_standalone(passed_online, passed_global_relay, passed_global_pace_partne
     remove_inactive_thread = threading.Thread(target=remove_inactive)
     remove_inactive_thread.start()
     logger.info("Server version %s is running." % ZWIFT_VER_CUR)
-    server = WSGIServer(('0.0.0.0', 443), app, certfile='%s/cert-zwift-com.pem' % SSL_DIR, keyfile='%s/key-zwift-com.pem' % SSL_DIR, log=logger)
+    host = os.environ.get('ZOFFLINE_API_HOST', '0.0.0.0')
+    port = int(os.environ.get('ZOFFLINE_API_PORT', 443))
+    use_cert = os.environ.get('ZOFFLINE_API_USE_CERT', 'true').lower() == 'true'
+
+    logger.info("Server running on %s:%d using certificate: %d", host, port, use_cert)
+
+    cert_kwargs = {
+        'certfile': '%s/cert-zwift-com.pem' % SSL_DIR,
+        'keyfile': '%s/key-zwift-com.pem' % SSL_DIR,
+    }
+    if not use_cert:
+        cert_kwargs = {}
+    server = WSGIServer((host, port), app, log=logger, **cert_kwargs)
     server.serve_forever()
 
 #    app.run(ssl_context=('%s/cert-zwift-com.pem' % SSL_DIR, '%s/key-zwift-com.pem' % SSL_DIR), port=443, threaded=True, host='0.0.0.0') # debug=True, use_reload=False)


### PR DESCRIPTION
This flexibility allows to run zoffline on kubernetes with handling tls termination on ingress controller.
It also allows to run Pod without root permissions (port binding).