### PR TITLE
Change URL for password recovey

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,9 @@ To enable support for multiple users perform the steps below:
   * TCP ports 80, 443, 3025 and UDP port 3024 will need to be open on the PC running zoffline if it's running remotely.
 * Start Zwift and create an account.
   * This account will only exist on your zoffline server and has no relation with your actual Zwift account.
-* To enable the password reset feature: create a ``gmail_credentials.txt`` file in the ``storage`` directory containing the login credentials of a Gmail account. You need to access https://security.google.com/settings/security/apppasswords and create an app password to allow the login from the server.
+* To enable the password reset feature: create a ``gmail_credentials.txt`` file in the ``storage`` directory containing the login credentials of a Gmail account.
+  * You need to access https://security.google.com/settings/security/apppasswords and create an app password to allow the login from the server.
+  * Optionally, the third line can contain the host for the recovery URL (server IP will be used by default).
 
 </details>
 

--- a/zwift_offline.py
+++ b/zwift_offline.py
@@ -97,6 +97,7 @@ ZWIFT_VER_CUR = ET.parse('%s/cdn/gameassets/Zwift_Updates_Root/Zwift_ver_cur.xml
 # For auth server
 AUTOLAUNCH_FILE = "%s/auto_launch.txt" % STORAGE_DIR
 SERVER_IP_FILE = "%s/server-ip.txt" % STORAGE_DIR
+FAKE_DNS_FILE = "%s/fake-dns.txt" % STORAGE_DIR
 if os.path.exists(SERVER_IP_FILE):
     with open(SERVER_IP_FILE, 'r') as f:
         server_ip = f.read().rstrip('\r\n')
@@ -686,7 +687,10 @@ def send_mail(username, token):
             message['From'] = sender_email
             message['To'] = username
             message['Subject'] = "Password reset"
-            content = "https://secure.zwift.com/login/?token=%s" % (token)
+            if os.path.exists(FAKE_DNS_FILE):
+            	content = "https://secure.zwift.com/login/?token=%s" % (token)
+            else:
+            	content = "https://%s/login/?token=%s" % (server_ip, token)
             message.attach(MIMEText(content, 'plain'))
             server.sendmail(sender_email, username, message.as_string())
             server.close()

--- a/zwift_offline.py
+++ b/zwift_offline.py
@@ -97,7 +97,6 @@ ZWIFT_VER_CUR = ET.parse('%s/cdn/gameassets/Zwift_Updates_Root/Zwift_ver_cur.xml
 # For auth server
 AUTOLAUNCH_FILE = "%s/auto_launch.txt" % STORAGE_DIR
 SERVER_IP_FILE = "%s/server-ip.txt" % STORAGE_DIR
-FAKE_DNS_FILE = "%s/fake-dns.txt" % STORAGE_DIR
 if os.path.exists(SERVER_IP_FILE):
     with open(SERVER_IP_FILE, 'r') as f:
         server_ip = f.read().rstrip('\r\n')
@@ -681,16 +680,14 @@ def send_mail(username, token):
         with open('%s/gmail_credentials.txt' % STORAGE_DIR) as f:
             sender_email = f.readline().rstrip('\r\n')
             password = f.readline().rstrip('\r\n')
+            host = f.readline().rstrip('\r\n')
         with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=ssl.create_default_context()) as server:
             server.login(sender_email, password)
             message = MIMEMultipart()
             message['From'] = sender_email
             message['To'] = username
             message['Subject'] = "Password reset"
-            if os.path.exists(FAKE_DNS_FILE):
-            	content = "https://secure.zwift.com/login/?token=%s" % (token)
-            else:
-            	content = "https://%s/login/?token=%s" % (server_ip, token)
+            content = "https://%s/login/?token=%s" % (host if host else server_ip, token)
             message.attach(MIMEText(content, 'plain'))
             server.sendmail(sender_email, username, message.as_string())
             server.close()

--- a/zwift_offline.py
+++ b/zwift_offline.py
@@ -686,7 +686,7 @@ def send_mail(username, token):
             message['From'] = sender_email
             message['To'] = username
             message['Subject'] = "Password reset"
-            content = "https://%s/login/?token=%s" % (server_ip, token)
+            content = "https://secure.zwift.com/login/?token=%s" % (token)
             message.attach(MIMEText(content, 'plain'))
             server.sendmail(sender_email, username, message.as_string())
             server.close()


### PR DESCRIPTION
Change URL for Password recovery changing server_ip to secure.zwift.com to make the URL sent by mail to work if server is a contained of works behind a reverse proxy