### PR TITLE
chore: Improve Bot section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ To enable support for multiple users perform the steps below:
 
 <details><summary>Bots</summary>
 
+* Create a file ``server-ip.txt`` inside the ``storage`` folder and set it to the IP of the machine running the server. If it's the machine running Zwift use ``127.0.0.1``. If you're using Docker and not exposing the ports on localhost (the ``-p`` flag or ``ports`` in ``docker-compose.yaml`` use the IP of the docker container. 
 * Create a file ``enable_bots.txt`` inside the ``storage`` folder to load ghosts as bots, they will keep riding around regardless of the route you are riding.
 * Optionally, ``enable_bots.txt`` can contain a multiplier value (be careful, if the resulting number of bots is too high, it may cause performance issues or not work at all).
 * Type ``.groupbots`` in chat to group the bots.


### PR DESCRIPTION
In order to run bots the server-ip.txt file must be set, otherwise Zwift will throw error logs similar to "ERROR] Error connecting to TCP host 172.18.0.2:3025 [60] Operation timed out". This should be set to localhost in the default set-up provided in the readme since it's either running on localhost, or all the ports are being exposed on the docker-container.

This commit extends the "Bots" section of the README in order to explain this.