### PR TITLE
Update CI workflow Docker Buildx to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - 'master'
+      - "master"
     tags:
       - "*"
 
@@ -36,7 +36,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Updates GitHub actions CI workflow to use Docker Buildx v6 and standardize branch quotes.
