### PR TITLE
Update zwift_offline.py

### DIFF
--- a/zwift_offline.py
+++ b/zwift_offline.py
@@ -148,8 +148,7 @@ if not os.path.exists(SECRET_KEY_FILE):
         f.write(os.urandom(16))
 with open(SECRET_KEY_FILE, 'rb') as f:
     app.config['SECRET_KEY'] = f.read()
-app.config['MAX_CONTENT_LENGTH'] = 6 * 1024 * 1024  # A typical .fit file with power, cadence, and heartrate data recorded in December 2024 is approximately 1.3 MB / 4 hours. 
-                                                    # Increased to accommodate ~12 hours of activity, .fit file with power, cadence, and heartrate data recorded in January 2026 is approximately 4.2 MB
+app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024
 db = SQLAlchemy()
 db.init_app(app)
 


### PR DESCRIPTION
Increasing MAX_CONTENT_LENGTH to accommodate ~12 hours of activity, .fit file with power, cadence, and heartrate data recorded in January 2026 is approximately 4.2 MB