### PR TITLE
feat: add COROS activity upload support

### DIFF
--- a/cdn/static/web/launcher/coros.html
+++ b/cdn/static/web/launcher/coros.html
@@ -1,0 +1,47 @@
+{% extends "./layout.html" %}
+{% block content %}
+  <h1><div class="text-shadow">COROS</div></h1>
+  {% if username != "zoffline" %}
+    <h4 class="text-shadow">Logged in as {{ username }}</h4>
+  {% endif %}
+  <div class="row">
+    <div class="col-md-12">
+      <a href="{{ url_for('settings', username=username) }}" class="btn btn-sm btn-secondary">Back</a>
+      {% if email or password %}
+        <a href="/delete/coros_credentials.bin" class="btn btn-sm btn-danger">Remove credentials</a>
+      {% endif %}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-6 col-md-5 top-buffer">
+      <form id="coros" action="{{ url_for('coros', username=username) }}" method="post">
+        <div class="row">
+          <div class="col-md-12">
+            <label class="col-form-label col-form-label-sm text-shadow">COROS email</label>
+            <input type="text" id="email" name="email" value="{{ email }}" class="form-control form-control-sm">
+          </div>
+          <div class="col-md-12">
+            <label class="col-form-label col-form-label-sm text-shadow">COROS password</label>
+            <input type="password" id="password" name="password" value="{{ password }}" class="form-control form-control-sm">
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-12 top-buffer">
+            <input type="submit" value="Submit" class="btn btn-sm btn-light">
+          </div>
+        </div>
+      </form>
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <ul class="list-group top-buffer">
+          {% for message in messages %}
+            <li class="list-group-item py-2">
+              <div class="text-shadow">{{ message }}</div>
+            </li>
+          {% endfor %}
+          </ul>
+        {% endif %}
+      {% endwith %}
+    </div>
+  </div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ stravalib==1.1.0
 dnspython==2.6.1
 fitdecode==0.10.0
 werkzeug==3.1.5
+boto3==1.37.0
+urllib3==2.3.0
+certifi==2025.1.1

--- a/scripts/coros_client.py
+++ b/scripts/coros_client.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+
+"""
+COROS API client for zoffline.
+Handles login, OSS credential acquisition, S3 upload, and activity registration.
+"""
+
+import hashlib
+import json
+import os
+import sys
+import urllib3
+import certifi
+from io import BytesIO
+
+# Import boto3 for S3 uploads
+try:
+    import boto3
+    from boto3.s3.transfer import TransferConfig
+except ImportError:
+    boto3 = None
+
+urllib3.disable_warnings()
+
+
+# COROS Region Configuration
+REGION_CONFIG = {
+    1: {  # International
+        'teamapi': 'https://teamapi.coros.com',
+        'bucket': 'coros-s3',
+        'service': 'aws',
+        'oss_endpoint': 'https://s3.eu-central-1.amazonaws.com',
+    },
+    2: {  # China
+        'teamapi': 'https://teamcnapi.coros.com',
+        'bucket': 'coros-oss',
+        'service': 'aliyun',
+        'oss_endpoint': 'https://oss-cn-beijing.aliyuncs.com',
+    },
+    3: {  # Europe
+        'teamapi': 'https://teameuapi.coros.com',
+        'bucket': 'eu-coros',
+        'service': 'aws',
+        'oss_endpoint': 'https://s3.eu-central-1.amazonaws.com',
+    },
+}
+
+
+def _decode_sts_credentials(credentials):
+    """Decode STS credentials from COROS API response."""
+    salt = "9y78gpoERW4lBNYL"
+    encoded_cred = credentials.replace(salt, '')
+    decoded = base64.b64decode(encoded_cred).decode('utf-8')
+    return json.loads(decoded)
+
+
+class CorosClient:
+    """COROS API client."""
+
+    def __init__(self, email, password):
+        self.email = email
+        self.password = password
+        self.req = urllib3.PoolManager(cert_reqs='CERT_REQUIRED', ca_certs=certifi.where())
+        self.access_token = None
+        self.user_id = None
+        self.region_id = None
+        self._teamapi = None
+        self._sts_credentials = None
+
+    @property
+    def teamapi(self):
+        if self._teamapi:
+            return self._teamapi
+        return REGION_CONFIG[1]['teamapi']
+
+    @teamapi.setter
+    def teamapi(self, value):
+        self._teamapi = value
+
+    def login(self):
+        """Login to COROS with email and MD5(password)."""
+        # Use default international teamapi for login first
+        login_url = f"{REGION_CONFIG[1]['teamapi']}/account/login"
+        login_data = {
+            "account": self.email,
+            "pwd": hashlib.md5(self.password.encode()).hexdigest(),
+            "accountType": 2,
+        }
+        headers = {
+            "Accept": "application/json, text/plain, */*",
+            "Content-Type": "application/json;charset=UTF-8",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            "referer": REGION_CONFIG[1]['teamapi'],
+            "origin": REGION_CONFIG[1]['teamapi'],
+        }
+
+        try:
+            response = self.req.request(
+                'POST',
+                login_url,
+                body=json.dumps(login_data).encode('utf-8'),
+                headers=headers
+            )
+            login_response = json.loads(response.data)
+
+            if login_response.get("result") != "0000":
+                raise CorosLoginError(login_response.get("message", "Unknown login error"))
+
+            self.access_token = login_response["data"]["accessToken"]
+            self.user_id = login_response["data"]["userId"]
+            self.region_id = login_response["data"]["regionId"]
+
+            # Set region-specific config
+            if self.region_id in REGION_CONFIG:
+                self.teamapi = REGION_CONFIG[self.region_id]['teamapi']
+            else:
+                # Default to international
+                self.teamapi = REGION_CONFIG[1]['teamapi']
+                self.region_id = 1
+
+        except urllib3.exceptions.HTTPError as e:
+            raise CorosLoginError(f"Network error during login: {e}")
+        except (json.JSONDecodeError, KeyError) as e:
+            raise CorosLoginError(f"Invalid response during login: {e}")
+
+    def _get_sts_token(self):
+        """Get OSS temporary credentials from COROS."""
+        if self.region_id not in REGION_CONFIG:
+            raise CorosError(f"Unsupported region: {self.region_id}")
+
+        region_cfg = REGION_CONFIG[self.region_id]
+        app_id = "1660188068672619112"
+        sign = "877571111A1EE5316E4B590103D4B5B3"
+
+        sts_url = (
+            f"https://faq.coros.com/openapi/oss/sts"
+            f"?bucket={region_cfg['bucket']}&service={region_cfg['service']}"
+            f"&app_id={app_id}&sign={sign}&v=2"
+        )
+
+        try:
+            response = self.req.request('GET', sts_url)
+            sts_response = json.loads(response.data)
+
+            if sts_response.get("code") != 200:
+                raise CorosError(f"Failed to get STS token: code={sts_response.get('code')}")
+
+            self._sts_credentials = sts_response["data"]["credentials"]
+
+        except urllib3.exceptions.HTTPError as e:
+            raise CorosError(f"Network error getting STS token: {e}")
+        except json.JSONDecodeError as e:
+            raise CorosError(f"Invalid STS token response: {e}")
+
+    def _get_s3_client(self):
+        """Get S3 client using STS credentials."""
+        if boto3 is None:
+            raise CorosError("boto3 is required for S3 upload. Install with: pip install boto3")
+
+        if self._sts_credentials is None:
+            self._get_sts_token()
+
+        region_cfg = REGION_CONFIG[self.region_id]
+        cred = _decode_sts_credentials(self._sts_credentials)
+
+        if region_cfg['service'] == 'aws':
+            client = boto3.client(
+                "s3",
+                aws_access_key_id=cred["AccessKeyId"],
+                aws_secret_access_key=cred["SecretAccessKey"],
+                aws_session_token=cred["SessionToken"],
+                endpoint_url=region_cfg['oss_endpoint'],
+            )
+        else:
+            # Aliyun OSS - use endpoint URL
+            client = boto3.client(
+                "s3",
+                aws_access_key_id=cred["AccessKeyId"],
+                aws_secret_access_key=cred["SecretAccessKey"],
+                aws_session_token=cred.get("SessionToken", ""),
+                endpoint_url=region_cfg['oss_endpoint'],
+            )
+
+        return client, region_cfg
+
+    def upload_fit_file(self, fit_data, file_name):
+        """
+        Upload FIT file to COROS OSS and register activity.
+
+        Args:
+            fit_data: bytes - FIT file content
+            file_name: str - original file name
+
+        Returns:
+            bool - True if upload succeeded
+        """
+        if self.access_token is None:
+            raise CorosError("Not logged in. Call login() first.")
+
+        # Step 1: Get STS credentials
+        if self._sts_credentials is None:
+            self._get_sts_token()
+
+        region_cfg = REGION_CONFIG[self.region_id]
+
+        # Step 2: Calculate MD5 of FIT data
+        file_md5 = hashlib.md5(fit_data).hexdigest()
+
+        # Step 3: Upload to S3
+        if region_cfg['service'] == 'aws':
+            s3_client, _ = self._get_s3_client()
+            bucket = region_cfg['bucket']
+            s3_key = f"fit/{self.user_id}/{file_md5}.fit"
+
+            config = TransferConfig(
+                multipart_threshold=5 * 1024 * 1024,
+                max_concurrency=4,
+                multipart_chunksize=5 * 1024 * 1024,
+                use_threads=True
+            )
+
+            try:
+                s3_client.put_object(
+                    Bucket=bucket,
+                    Key=s3_key,
+                    Body=fit_data,
+                )
+            except Exception as e:
+                raise CorosError(f"S3 upload failed: {e}")
+
+        else:
+            raise CorosError(f"Unsupported service: {region_cfg['service']}")
+
+        # Step 4: Register activity with COROS
+        size = len(fit_data)
+        oss_object = f"fit/{self.user_id}/{file_md5}.fit"
+
+        upload_url = f"{self.teamapi}/activity/fit/import"
+        headers = {
+            "Accept": "application/json, text/plain, */*",
+            "accesstoken": self.access_token,
+        }
+
+        data = {
+            "source": 1,
+            "timezone": 32,
+            "bucket": bucket,
+            "md5": file_md5,
+            "size": size,
+            "object": oss_object,
+            "serviceName": region_cfg['service'],
+            "oriFileName": file_name
+        }
+
+        try:
+            response = self.req.request(
+                method='POST',
+                url=upload_url,
+                fields={"jsonParameter": json.dumps(data)},
+                headers=headers
+            )
+            upload_response = json.loads(response.data)
+
+            if upload_response.get("result") == "0000":
+                status = upload_response.get("data", {}).get("status")
+                if status == 2:
+                    return True
+                raise CorosError(f"Activity registration failed: status={status}")
+            else:
+                raise CorosError(f"Activity registration failed: {upload_response.get('message')}")
+
+        except urllib3.exceptions.HTTPError as e:
+            raise CorosError(f"Network error during activity registration: {e}")
+
+
+class CorosError(Exception):
+    """COROS API error."""
+    pass
+
+
+class CorosLoginError(CorosError):
+    """COROS login error."""
+    pass
+
+
+if __name__ == "__main__":
+    # Simple test
+    import getpass
+
+    email = input("COROS email: ")
+    password = getpass.getpass("COROS password: ")
+
+    client = CorosClient(email, password)
+    try:
+        client.login()
+        print(f"Login successful! user_id={client.user_id}, region_id={client.region_id}")
+    except CorosLoginError as e:
+        print(f"Login failed: {e}")

--- a/scripts/coros_upload.py
+++ b/scripts/coros_upload.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+"""
+COROS activity upload script for zoffline.
+This script is called by activity_uploads() in zwift_offline.py after an activity is saved.
+"""
+
+import logging
+import os
+import sys
+
+logger = logging.getLogger('zoffline')
+
+
+def coros_upload(player_id, activity):
+    """
+    Upload activity to COROS.
+
+    Args:
+        player_id: int - player's ID
+        activity: activity_pb2.Activity - the activity to upload
+
+    Returns:
+        bool - True if upload succeeded or was skipped, False on error
+    """
+    credentials_file = 'storage/%s/coros_credentials.bin' % player_id
+
+    if not os.path.exists(credentials_file):
+        logger.debug("COROS credentials not found, skipping upload")
+        return True
+
+    try:
+        email, password = decrypt_credentials(credentials_file)
+        if not email or not password:
+            logger.warning("COROS credentials file exists but is empty")
+            return True
+
+        from scripts.coros_client import CorosClient, CorosError, CorosLoginError
+
+        client = CorosClient(email, password)
+        client.login()
+
+        fit_data = activity.fit
+        file_name = activity.fit_filename or "activity.fit"
+
+        success = client.upload_fit_file(fit_data, file_name)
+
+        if success:
+            logger.info("COROS upload succeeded for player %s activity %s", player_id, activity.id)
+        else:
+            logger.warning("COROS upload returned failure for player %s activity %s", player_id, activity.id)
+
+        return success
+
+    except CorosLoginError as e:
+        logger.warning("COROS login failed for player %s: %s", player_id, e)
+        return True
+    except CorosError as e:
+        logger.warning("COROS upload failed for player %s: %s", player_id, e)
+        return False
+    except Exception as e:
+        logger.warning("COROS upload error for player %s: %s", player_id, e)
+        return False
+
+
+def decrypt_credentials(file):
+    """Decrypt credentials from AES encrypted file. Uses credentials_key from zwift_offline module."""
+    cred = ('', '')
+    if os.path.isfile(file):
+        try:
+            from zwift_offline import credentials_key
+            with open(file, 'rb') as f:
+                from Crypto.Cipher import AES
+                cipher_suite = AES.new(credentials_key, AES.MODE_CFB, iv=f.read(16))
+                lines = cipher_suite.decrypt(f.read()).decode('UTF-8').splitlines()
+                cred = (lines[0], lines[1])
+        except Exception as e:
+            logger.warning("Failed to decrypt COROS credentials: %s", e)
+    return cred

--- a/scripts/set_coros_credentials.py
+++ b/scripts/set_coros_credentials.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+"""
+Set COROS credentials for zoffline.
+This script encrypts and saves COROS email/password to coros_credentials.bin.
+"""
+
+import getpass
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, SCRIPT_DIR)
+
+
+def set_coros_credentials(player_id):
+    """Interactively set COROS credentials for a player."""
+    credentials_file = os.path.join(SCRIPT_DIR, "storage", str(player_id), "coros_credentials.bin")
+
+    print("COROS Credentials Setup")
+    print("=" * 40)
+    print()
+
+    email = input("COROS email: ").strip()
+    if not email:
+        print("Email cannot be empty")
+        return False
+
+    password = getpass.getpass("COROS password: ").strip()
+    if not password:
+        print("Password cannot be empty")
+        return False
+
+    # Confirm password
+    password_confirm = getpass.getpass("Confirm password: ").strip()
+    if password != password_confirm:
+        print("Passwords do not match")
+        return False
+
+    try:
+        from Crypto.Cipher import AES
+
+        credentials_key_file = os.path.join(SCRIPT_DIR, "storage", "credentials-key.bin")
+        if not os.path.exists(credentials_key_file):
+            print("Error: credentials-key.bin not found. Run zoffline at least once.")
+            return False
+
+        with open(credentials_key_file, 'rb') as f:
+            credentials_key = f.read()
+
+        cipher_suite = AES.new(credentials_key, AES.MODE_CFB)
+        with open(credentials_file, 'wb') as f:
+            f.write(cipher_suite.iv)
+            f.write(cipher_suite.encrypt((email + '\n' + password).encode('UTF-8')))
+
+        print()
+        print(f"Credentials saved to: {credentials_file}")
+        return True
+
+    except Exception as e:
+        print(f"Error saving credentials: {e}")
+        return False
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Set COROS credentials for zoffline')
+    parser.add_argument('player_id', type=int, help='Player ID')
+    args = parser.parse_args()
+
+    success = set_coros_credentials(args.player_id)
+    sys.exit(0 if success else 1)

--- a/zwift_offline.py
+++ b/zwift_offline.py
@@ -62,6 +62,7 @@ import fitness_pb2
 import structured_events_pb2
 
 import online_sync
+import scripts.coros_upload as coros_upload
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 logger = logging.getLogger('zoffline')
@@ -960,6 +961,19 @@ def intervals(username):
     return render_template("intervals.html", username=current_user.username, aid=cred[0], akey=cred[1])
 
 
+@app.route("/coros/<username>/", methods=["GET", "POST"])
+@login_required
+def coros(username):
+    file = '%s/%s/coros_credentials.bin' % (STORAGE_DIR, current_user.player_id)
+    if request.method == "POST":
+        if request.form['email'] == "" or request.form['password'] == "":
+            flash("COROS credentials can't be empty.")
+            return render_template("coros.html", username=current_user.username, email=request.form['email'], password=request.form['password'])
+        encrypt_credentials(file, (request.form['email'], request.form['password']))
+    cred = decrypt_credentials(file)
+    return render_template("coros.html", username=current_user.username, email=cred[0], password=cred[1])
+
+
 @app.route("/user/<username>/")
 @login_required
 def user_home(username):
@@ -1088,7 +1102,7 @@ def download_avatarLarge(player_id):
 @app.route("/delete/<path:filename>", methods=["GET"])
 @login_required
 def delete(filename):
-    credentials = ['zwift_credentials.bin', 'intervals_credentials.bin']
+    credentials = ['zwift_credentials.bin', 'intervals_credentials.bin', 'coros_credentials.bin']
     strava = ['strava_api.bin', 'strava_token.txt']
     garmin = ['garmin_credentials.bin', 'garth/oauth1_token.json']
     if filename not in credentials + strava + garmin:
@@ -2475,6 +2489,7 @@ def activity_uploads(player_id, activity):
     runalyze_upload(player_id, activity)
     intervals_upload(player_id, activity)
     zwift_upload(player_id, activity)
+    coros_upload(player_id, activity)
     logout_player(player_id)
 
 @app.route('/api/profiles/<int:player_id>/activities/<int:activity_id>', methods=['PUT', 'DELETE'])


### PR DESCRIPTION
- Add scripts/coros_client.py: COROS API client with login, STS token acquisition, S3 upload, and activity registration
- Add scripts/coros_upload.py: upload function called after activity save
- Add scripts/set_coros_credentials.py: CLI tool for credential input
- Add cdn/static/web/launcher/coros.html: web UI for COROS credentials
- Modify zwift_offline.py: add /coros route, activity_uploads() hook
- Add boto3, urllib3, certifi to requirements.txt